### PR TITLE
add semantic-release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || 'refs/heads/beta' || github.ref == 'refs/heads/alpha'
     needs: build
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,3 +27,17 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx -p @semantic-release/changelog -p @semantic-release/git -p semantic-release semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,20 @@
+{
+    "branches": [
+        "master",
+        {
+            "name": "beta",
+            "prerelease": true
+        },
+        {
+            "name": "alpha",
+            "prerelease": true
+        }
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/changelog",
+        "@semantic-release/git",
+        "@semantic-release/github"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# [0.4.0](https://github.com/Silthus/go-generator-lib/compare/v0.3.0...v0.4.0) (2021-09-17)
+
+
+### Bug Fixes
+
+* **release:** remove binary builds for lib ([6942f9c](https://github.com/Silthus/go-generator-lib/commit/6942f9c18d4e186a71de5de6c3fbf7deb6eacb2b))
+
+
+### Features
+
+* initial release ([6ed442f](https://github.com/Silthus/go-generator-lib/commit/6ed442f2f84faa083a9a373af652e0b9c88158f2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.0.0](https://github.com/Silthus/go-generator-lib/compare/v0.3.0...v1.0.0) (2021-09-17)
+
+
+### chore
+
+* **release:** setup semantic-release ([2121cbb](https://github.com/Silthus/go-generator-lib/commit/2121cbba294d0d2966b4500a6de1040160ff17fa))
+
+
+### BREAKING CHANGES
+
+* **release:** all commits now require the conventional commit format
+
 # [0.4.0](https://github.com/Silthus/go-generator-lib/compare/v0.3.0...v0.4.0) (2021-09-17)
 
 


### PR DESCRIPTION
Added semantic-release workflow to automatically publish releases and versions on push to the following branches:
- `master`
- `beta`
- `alpha`

The commit messages need to be in the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/) for this to work.
The commit https://github.com/Silthus/go-generator-lib/commit/2121cbba294d0d2966b4500a6de1040160ff17fa bumps the version to 1.0.0